### PR TITLE
Add Apple Music playlist for a broader reach

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@
 ** Change requests for bands that are already in the list
    [[https://github.com/Lodifice/final-countdown/issues/new?template=Bug_report.md][Create an issue]].
 * Want to listen to the goodness?
-  It's now possible to do so on [[https://open.spotify.com/user/marauderxtreme/playlist/7q3YCs5ioZhIMbZpVUknEf][Spotify]].
+  It's now possible to do so on [[https://open.spotify.com/user/marauderxtreme/playlist/7q3YCs5ioZhIMbZpVUknEf][Spotify]] or [[https://music.apple.com/playlist/pl.u-xK8PUpKJag7][Apple Music]].
   It gets updated fairly regular after every Pull Request goes through.
   Don't have Spotify but want to have a look at the current state? I got you [[https://open.spotify.com/embed/user/marauderxtreme/playlist/7q3YCs5ioZhIMbZpVUknEf][covered]].
 * License


### PR DESCRIPTION
I hereby declare that:

* [x] I preserved the structure of the `playlist.org` file!
* [x] I preserved the alphabetical order!
* [x] I used spaces instead of tabs for indentation!

Added Apple Music Playlist to README and didn't touch the `playlist.org`
